### PR TITLE
Possible fix

### DIFF
--- a/LazyVStackStutter/Shared/ContentView.swift
+++ b/LazyVStackStutter/Shared/ContentView.swift
@@ -12,16 +12,25 @@ let colors = [Color.blue, Color.red, Color.green, Color.orange, Color.pink, Colo
 struct ContentView: View {
   @State var items: [Message] = MockData.randomMessages(count: 100)
   
+  /// In order to prevent jitter when scrolling to the top of the scroll view, this value should be larger than the max number of items that will fit on one screen.
+  let firstItems = 15
+  
   var body: some View {
     VStack {
       Button("Shuffle items") {
         items = MockData.randomMessages(count: 100)
       }
       ScrollView {
-        LazyVStack(spacing: 10) {
-          ForEach(items) { item in
+        VStack {
+          ForEach(items.prefix(firstItems)) { item in
             Text(item.text)
               .background(colors.randomElement()!)
+          }
+          LazyVStack(spacing: 10) {
+            ForEach(items.dropFirst(firstItems)) { item in
+              Text(item.text)
+                .background(colors.randomElement()!)
+            }
           }
         }
       }


### PR DESCRIPTION
Added a VStack for the first 15 items (enough to cover the full screen height with buffer). This prevents stuttering when scrolling to the top of the scroll view.